### PR TITLE
Fertilization Control

### DIFF
--- a/custom_components/simple_plant/binary_sensor.py
+++ b/custom_components/simple_plant/binary_sensor.py
@@ -153,6 +153,91 @@ class SimplePlantProblem(SimplePlantBinarySensor):
         self.async_write_ha_state()
 
 
+class SimplePlantFertilizationBinarySensor(SimplePlantBinarySensor):
+    """Base class for fertilization binary sensors."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super(SimplePlantBinarySensor, self).async_added_to_hass()
+        device = self.coordinator.device
+
+        # Subscribe to fertilization state changes
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                f"date.{DOMAIN}_last_fertilized_{device}",
+                self._update_state,
+            )
+        )
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                f"number.{DOMAIN}_days_between_fertilizations_{device}",
+                self._update_state,
+            )
+        )
+        self.async_on_remove(
+            async_track_time_change(
+                self.hass,
+                self._update_state,
+                hour=0,
+                minute=0,
+                second=0,
+            )
+        )
+
+        # Initial update
+        await self._update_state()
+
+    def get_dates(self) -> dict | None:
+        """Get fertilizer dates from coordinator."""
+        return self.coordinator.get_fertilizer_dates()
+
+    async def _update_state(
+        self,
+        _event: Event[EventStateChangedData] | datetime | None = None,
+    ) -> None:
+        """Update the binary sensor state based on other entities."""
+        raise NotImplementedError
+
+
+class SimplePlantFertilizationTodo(SimplePlantFertilizationBinarySensor):
+    """simple_plant binary_sensor for fertilization todo."""
+
+    _fallback_value = False
+
+    async def _update_state(self, _event: Event | None = None) -> None:
+        """Update the binary sensor state based on fertilization entities."""
+        dates = self.get_dates()
+
+        if not dates:
+            return
+
+        self._attr_native_value = (
+            as_local(dates["today"]).date() >= as_local(dates["next_fertilization"]).date()
+        )
+        self.async_write_ha_state()
+
+
+class SimplePlantFertilizationProblem(SimplePlantFertilizationBinarySensor):
+    """simple_plant binary_sensor for fertilization problem."""
+
+    _fallback_value = False
+    _attr_translation_key = "problem_fertilization"
+
+    async def _update_state(self, _event: Event | None = None) -> None:
+        """Update the binary sensor state based on fertilization entities."""
+        dates = self.get_dates()
+
+        if not dates:
+            return
+
+        self._attr_native_value = (
+            as_local(dates["today"]).date() > as_local(dates["next_fertilization"]).date()
+        )
+        self.async_write_ha_state()
+
+
 ENTITIES = [
     {
         "class": SimplePlantTodo,
@@ -171,6 +256,25 @@ ENTITIES = [
             name="Simple Plant Binary Sensor Problem",
             device_class=BinarySensorDeviceClass.PROBLEM,
             icon="mdi:water-alert-outline",
+        ),
+    },
+    {
+        "class": SimplePlantFertilizationTodo,
+        "description": BinarySensorEntityDescription(
+            key="todo_fertilization",
+            translation_key="todo_fertilization",
+            name="Simple Plant Binary Sensor Fertilization Todo",
+            icon="mdi:sprout",
+        ),
+    },
+    {
+        "class": SimplePlantFertilizationProblem,
+        "description": BinarySensorEntityDescription(
+            key="problem_fertilization",
+            translation_key="problem_fertilization",
+            name="Simple Plant Binary Sensor Fertilization Problem",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            icon="mdi:leaf-off",
         ),
     },
 ]

--- a/custom_components/simple_plant/button.py
+++ b/custom_components/simple_plant/button.py
@@ -25,6 +25,11 @@ ENTITY_DESCRIPTIONS = (
         translation_key="mark_watered",
         icon="mdi:watering-can",
     ),
+    ButtonEntityDescription(
+        key="mark_fertilized",
+        translation_key="mark_fertilized",
+        icon="mdi:sprout",
+    ),
 )
 
 
@@ -72,4 +77,7 @@ class SimplePlantButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self.coordinator.async_mark_as_watered_toggle()
+        if self.entity_description.key == "mark_fertilized":
+            await self.coordinator.async_mark_as_fertilized_toggle()
+        else:
+            await self.coordinator.async_mark_as_watered_toggle()

--- a/custom_components/simple_plant/config_flow.py
+++ b/custom_components/simple_plant/config_flow.py
@@ -92,6 +92,17 @@ def user_form() -> vol.Schema:
                     unit_of_measurement="days",
                 ),
             ),
+            vol.Required("last_fertilized"): selector.DateSelector(
+                selector.DateSelectorConfig(),
+            ),
+            vol.Required("days_between_fertilizations"): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1,
+                    max=365,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="days",
+                ),
+            ),
             vol.Required("health"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     {
@@ -163,6 +174,15 @@ class SimplePlantFlowHandler(ConfigFlow, domain=DOMAIN):
         # Verify date
         if "last_watered" in user_input:
             date = as_utc(as_local(datetime.fromisoformat(user_input["last_watered"])))
+            if date > utcnow():
+                return self.async_show_form(
+                    step_id="user",
+                    data_schema=user_form(),
+                    errors={"base": "invalid_future_date"},
+                )
+        # Verify fertilized date
+        if "last_fertilized" in user_input:
+            date = as_utc(as_local(datetime.fromisoformat(user_input["last_fertilized"])))
             if date > utcnow():
                 return self.async_show_form(
                     step_id="user",

--- a/custom_components/simple_plant/coordinator.py
+++ b/custom_components/simple_plant/coordinator.py
@@ -149,3 +149,91 @@ class SimplePlantCoordinator(DataUpdateCoordinator[dict]):
             "next_watering": last_watered_date + timedelta(days=nb_days),
             "today": utcnow(),
         }
+
+    async def async_set_last_fertilized(self, value: datetime) -> None:
+        """Change last fertilized date manually."""
+        new_value = as_utc(value)
+        if new_value > utcnow():
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_future_date",
+                translation_placeholders={},
+            )
+        await self.store.async_save_data(
+            self.device, {"last_fertilized": new_value.isoformat()}
+        )
+        await self.async_refresh()
+
+    async def async_mark_as_fertilized_toggle(self) -> None:
+        """Toggle last fertilized between old value and today."""
+        data = await self.store.async_get_data(self.device)
+        if data is None:
+            LOGGER.warning("%s: No data found in storage", self.device)
+            return
+
+        last_fertilized = None
+        old_last_fertilized = None
+        if "last_fertilized" in data:
+            last_fertilized = as_utc(
+                as_local(datetime.fromisoformat(data["last_fertilized"]))
+            )
+        if "_old_last_fertilized" in data:
+            old_last_fertilized = as_utc(
+                as_local(datetime.fromisoformat(data["_old_last_fertilized"]))
+            )
+
+        if last_fertilized and as_local(last_fertilized).date() != as_local(utcnow()).date():
+            await self.async_action_mark_as_fertilized(save_old=last_fertilized)
+        else:
+            await self.async_action_cancel_mark_as_fertilized(old_value=old_last_fertilized)
+
+    async def async_action_cancel_mark_as_fertilized(
+        self, old_value: datetime | None = None
+    ) -> None:
+        """Update last fertilized date to old value."""
+        if old_value:
+            await self.async_set_last_fertilized(as_utc(old_value))
+        else:
+            await self.async_action_mark_as_fertilized()
+
+    async def async_action_mark_as_fertilized(
+        self, save_old: datetime | None = None
+    ) -> None:
+        """Update last fertilized date today."""
+        today = utcnow()
+        if save_old:
+            await self.store.async_save_data(
+                self.device, {"_old_last_fertilized": as_utc(save_old).isoformat()}
+            )
+        await self.async_set_last_fertilized(today)
+
+    def get_fertilizer_dates(self) -> dict[str, datetime] | None:
+        """Get dates from relevant device entities states for fertilizer."""
+        states_to_get = {
+            "last_fertilized": f"date.{DOMAIN}_last_fertilized_{self.device}",
+            "nb_days": f"number.{DOMAIN}_days_between_fertilizations_{self.device}",
+        }
+
+        # Get states from hass
+        data = {key: self.hass.states.get(eid) for key, eid in states_to_get.items()}
+
+        # Check if all states are available
+        if any(
+            data[key] is None
+            or not data[key].state  # type: ignore noqa: PGH003
+            or data[key].state == "unavailable"  # type: ignore noqa: PGH003
+            for key in states_to_get
+        ):
+            LOGGER.warning("%s: Couldn't get all fertilizer states", self.device)
+            return None
+
+        states = {key: data.state for key, data in data.items() if data is not None}
+
+        last_fertilized_date = datetime.fromisoformat(states["last_fertilized"])
+        nb_days = float(states["nb_days"])
+
+        return {
+            "last_fertilized": last_fertilized_date,
+            "next_fertilization": last_fertilized_date + timedelta(days=nb_days),
+            "today": utcnow(),
+        }

--- a/custom_components/simple_plant/date.py
+++ b/custom_components/simple_plant/date.py
@@ -10,7 +10,7 @@ from homeassistant.components.date import (
     DateEntityDescription,
 )
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.dt import as_local, as_utc
+from homeassistant.util.dt import as_local, as_utc, utcnow
 
 from .const import DOMAIN
 from .coordinator import SimplePlantCoordinator
@@ -65,9 +65,13 @@ class SimplePlantDate(CoordinatorEntity[SimplePlantCoordinator], DateEntity):
 
         device = self.coordinator.device
 
-        self._fallback_value = as_local(
-            datetime.fromisoformat(str(entry.data.get(description.key)))
-        ).date()
+        raw_value = entry.data.get(description.key)
+        if raw_value is not None:
+            self._fallback_value = as_local(
+                datetime.fromisoformat(str(raw_value))
+            ).date()
+        else:
+            self._fallback_value = as_local(utcnow()).date()
 
         self.entity_id = f"date.{DOMAIN}_{description.key}_{device}"
         self._attr_unique_id = f"{DOMAIN}_{description.key}_{device}"

--- a/custom_components/simple_plant/date.py
+++ b/custom_components/simple_plant/date.py
@@ -27,6 +27,11 @@ ENTITY_DESCRIPTIONS = (
         translation_key="last_watered",
         icon="mdi:calendar-check",
     ),
+    DateEntityDescription(
+        key="last_fertilized",
+        translation_key="last_fertilized",
+        icon="mdi:calendar-star",
+    ),
 )
 
 
@@ -61,7 +66,7 @@ class SimplePlantDate(CoordinatorEntity[SimplePlantCoordinator], DateEntity):
         device = self.coordinator.device
 
         self._fallback_value = as_local(
-            datetime.fromisoformat(str(entry.data.get("last_watered")))
+            datetime.fromisoformat(str(entry.data.get(description.key)))
         ).date()
 
         self.entity_id = f"date.{DOMAIN}_{description.key}_{device}"
@@ -86,7 +91,10 @@ class SimplePlantDate(CoordinatorEntity[SimplePlantCoordinator], DateEntity):
         # Validate the date is not in the future
         dt = datetime.combine(value, datetime.min.time())
         new_val = as_utc(as_local(dt))
-        await self.coordinator.async_set_last_watered(new_val)
+        if self.entity_description.key == "last_fertilized":
+            await self.coordinator.async_set_last_fertilized(new_val)
+        else:
+            await self.coordinator.async_set_last_watered(new_val)
 
     @property
     def native_value(self) -> date | None:
@@ -94,7 +102,7 @@ class SimplePlantDate(CoordinatorEntity[SimplePlantCoordinator], DateEntity):
         if not self.coordinator.data:
             return None
 
-        date_str = self.coordinator.data.get("last_watered")
+        date_str = self.coordinator.data.get(self.entity_description.key)
         if not date_str:
             return None
 

--- a/custom_components/simple_plant/manifest.json
+++ b/custom_components/simple_plant/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "aiofiles"
     ],
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/custom_components/simple_plant/number.py
+++ b/custom_components/simple_plant/number.py
@@ -83,8 +83,8 @@ class SimplePlantNumber(NumberEntity):
         self.entity_id = f"number.{DOMAIN}_{description.key}_{device}"
         self._attr_unique_id = f"{DOMAIN}_{description.key}_{device}"
 
-        # set value
-        self._fallback_value = entry.data.get(description.key)
+        # set value — default to 30 days if not configured (migration from older entries)
+        self._fallback_value = entry.data.get(description.key) or 30
 
         # Set up device info
         self._attr_device_info = self.coordinator.device_info

--- a/custom_components/simple_plant/number.py
+++ b/custom_components/simple_plant/number.py
@@ -32,6 +32,15 @@ ENTITY_DESCRIPTIONS = (
         native_step=0,
         native_unit_of_measurement=UnitOfTime.DAYS,
     ),
+    NumberEntityDescription(
+        key="days_between_fertilizations",
+        translation_key="days_between_fertilizations",
+        device_class=NumberDeviceClass.DURATION,
+        mode=NumberMode.BOX,
+        icon="mdi:counter",
+        native_step=0,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+    ),
 )
 
 
@@ -75,7 +84,7 @@ class SimplePlantNumber(NumberEntity):
         self._attr_unique_id = f"{DOMAIN}_{description.key}_{device}"
 
         # set value
-        self._fallback_value = entry.data.get("days_between_waterings")
+        self._fallback_value = entry.data.get(description.key)
 
         # Set up device info
         self._attr_device_info = self.coordinator.device_info

--- a/custom_components/simple_plant/sensor.py
+++ b/custom_components/simple_plant/sensor.py
@@ -34,6 +34,12 @@ ENTITY_DESCRIPTIONS = (
         translation_key="next_watering",
         icon="mdi:clipboard-text-clock",
     ),
+    SensorEntityDescription(
+        device_class=SensorDeviceClass.DATE,
+        key="next_fertilization",
+        translation_key="next_fertilization",
+        icon="mdi:sprout-outline",
+    ),
 )
 
 COLOR_MAPPING = {"Today": "Goldenrod", "Late": "Tomato"}
@@ -45,10 +51,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    async_add_entities(
-        SimplePlantSensor(hass, entry, entity_description)
-        for entity_description in ENTITY_DESCRIPTIONS
-    )
+    entities = []
+    for entity_description in ENTITY_DESCRIPTIONS:
+        if entity_description.key == "next_fertilization":
+            entities.append(SimplePlantFertilizationSensor(hass, entry, entity_description))
+        else:
+            entities.append(SimplePlantSensor(hass, entry, entity_description))
+    async_add_entities(entities)
 
 
 class SimplePlantSensor(SensorEntity):
@@ -155,4 +164,70 @@ class SimplePlantSensor(SensorEntity):
 
         # Value
         self._attr_native_value = next_watering
+        self.async_write_ha_state()
+
+
+class SimplePlantFertilizationSensor(SimplePlantSensor):
+    """simple_plant sensor for next fertilization."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        await super(SimplePlantSensor, self).async_added_to_hass()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                f"date.{DOMAIN}_last_fertilized_{self.device}",
+                self._update_state,
+            )
+        )
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                f"number.{DOMAIN}_days_between_fertilizations_{self.device}",
+                self._update_state,
+            )
+        )
+        self.async_on_remove(
+            async_track_time_change(
+                self.hass,
+                self._update_state,
+                hour=0,
+                minute=0,
+                second=0,
+            )
+        )
+
+        # Initial update
+        await self._update_state()
+
+    async def _update_state(
+        self, _event: Event[EventStateChangedData] | datetime | None = None
+    ) -> None:
+        """Update the sensor state based on fertilization entities."""
+        dates = self.coordinator.get_fertilizer_dates()
+
+        if not dates:
+            return
+
+        # Color
+        today = as_local(dates["today"]).date()
+        next_fertilization = as_local(dates["next_fertilization"]).date()
+
+        color_key = "OK"
+        if today == next_fertilization:
+            color_key = "Today"
+        if today > next_fertilization:
+            color_key = "Late"
+
+        if color_key in COLOR_MAPPING:
+            self._attr_extra_state_attributes = {
+                "state_color": True,
+                "color": COLOR_MAPPING[color_key],
+            }
+        else:
+            self._attr_extra_state_attributes = {"state_color": False}
+
+        # Value
+        self._attr_native_value = next_fertilization
         self.async_write_ha_state()

--- a/custom_components/simple_plant/translations/en.json
+++ b/custom_components/simple_plant/translations/en.json
@@ -1,94 +1,114 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "description": "Provide base information for your new plant. If you need help with the configuration have a look here: https://github.com/ndesgranges/simple-plant",
-                "data": {
-                    "name": "Name",
-                    "last_watered": "Last time watered",
-                    "days_between_waterings": "Days between watering",
-                    "photo": "Photo",
-                    "health": "Current health (Optional)",
-                    "species": "Species/Variety of your plant (Optional)"
-                }
-            }
-        },
-        "error": {
-            "invalid_future_date": "Cannot set watering date in the future.",
-            "name_exist": "Plant with this name already exist",
-            "upload_failed_generic": "File upload failed, soomething went wrong.",
-            "upload_failed_type": "File upload failed, the file type is not a supported image type.",
-            "unknown": "Unknown error occurred."
-        },
-        "abort": {
-            "already_configured": "This entry is already configured."
+  "config": {
+    "step": {
+      "user": {
+        "description": "Provide base information for your new plant. If you need help with the configuration have a look here: https://github.com/ndesgranges/simple-plant",
+        "data": {
+          "name": "Name",
+          "last_watered": "Last time watered",
+          "days_between_waterings": "Days between watering",
+          "last_fertilized": "Last time fertilized",
+          "days_between_fertilizations": "Days between fertilizations",
+          "photo": "Photo",
+          "health": "Current health (Optional)",
+          "species": "Species/Variety of your plant (Optional)"
         }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "description": "Modify the species or picture of your plant. If you need help with the configuration have a look here: https://github.com/ndesgranges/simple-plant",
-                "data": {
-                    "photo": "Photo",
-                    "species": "Species/Variety of your plant (Optional)"
-                }
-            }
-        },
-        "error": {
-            "upload_failed_type": "File upload failed, the file type is not a supported image type."
-        }
+    "error": {
+      "invalid_future_date": "Cannot set watering date in the future.",
+      "name_exist": "Plant with this name already exist",
+      "upload_failed_generic": "File upload failed, soomething went wrong.",
+      "upload_failed_type": "File upload failed, the file type is not a supported image type.",
+      "unknown": "Unknown error occurred."
     },
-    "entity": {
-        "button": {
-            "mark_watered": {
-                "name": "Mark watered"
-            }
-        },
-        "binary_sensor": {
-            "todo": {
-                "name": "To Water"
-            },
-            "problem": {
-                "name": "Late Watering"
-            }
-        },
-        "date": {
-            "last_watered": {
-                "name": "Last time watered"
-            }
-        },
-        "image": {
-            "picture": {
-                "name": "Picture"
-            }
-        },
-        "number": {
-            "days_between_waterings": {
-                "name": "Days between waterings"
-            }
-        },
-        "select": {
-            "health": {
-                "name": "Current health",
-                "state": {
-                    "notset": "Not Set",
-                    "poor": "Poor",
-                    "fair": "Fair",
-                    "good": "Good",
-                    "verygood": "Very Good",
-                    "excellent": "Excellent"
-                }
-            }
-        },
-        "sensor": {
-            "next_watering": {
-                "name": "Next watering"
-            }
-        }
-    },
-    "exceptions": {
-        "invalid_future_date": {
-            "message": "Cannot set watering date in the future."
-        }
+    "abort": {
+      "already_configured": "This entry is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Modify the species or picture of your plant. If you need help with the configuration have a look here: https://github.com/ndesgranges/simple-plant",
+        "data": {
+          "photo": "Photo",
+          "species": "Species/Variety of your plant (Optional)"
+        }
+      }
+    },
+    "error": {
+      "upload_failed_type": "File upload failed, the file type is not a supported image type."
+    }
+  },
+  "entity": {
+    "button": {
+      "mark_watered": {
+        "name": "Mark watered"
+      },
+      "mark_fertilized": {
+        "name": "Mark fertilized"
+      }
+    },
+    "binary_sensor": {
+      "todo": {
+        "name": "To Water"
+      },
+      "problem": {
+        "name": "Late Watering"
+      },
+      "todo_fertilization": {
+        "name": "To Fertilize"
+      },
+      "problem_fertilization": {
+        "name": "Late Fertilization"
+      }
+    },
+    "date": {
+      "last_watered": {
+        "name": "Last time watered"
+      },
+      "last_fertilized": {
+        "name": "Last time fertilized"
+      }
+    },
+    "image": {
+      "picture": {
+        "name": "Picture"
+      }
+    },
+    "number": {
+      "days_between_waterings": {
+        "name": "Days between waterings"
+      },
+      "days_between_fertilizations": {
+        "name": "Days between fertilizations"
+      }
+    },
+    "select": {
+      "health": {
+        "name": "Current health",
+        "state": {
+          "notset": "Not Set",
+          "poor": "Poor",
+          "fair": "Fair",
+          "good": "Good",
+          "verygood": "Very Good",
+          "excellent": "Excellent"
+        }
+      }
+    },
+    "sensor": {
+      "next_watering": {
+        "name": "Next watering"
+      },
+      "next_fertilization": {
+        "name": "Next fertilization"
+      }
+    }
+  },
+  "exceptions": {
+    "invalid_future_date": {
+      "message": "Cannot set watering date in the future."
+    }
+  }
 }

--- a/custom_components/simple_plant/translations/pt-BR.json
+++ b/custom_components/simple_plant/translations/pt-BR.json
@@ -1,0 +1,114 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Forneça as informações básicas da sua nova planta. Se precisar de ajuda com a configuração, acesse: https://github.com/ndesgranges/simple-plant",
+        "data": {
+          "name": "Nome",
+          "last_watered": "Última rega",
+          "days_between_waterings": "Dias entre regas",
+          "last_fertilized": "Última adubação",
+          "days_between_fertilizations": "Dias entre adubações",
+          "photo": "Foto",
+          "health": "Saúde atual (Opcional)",
+          "species": "Espécie/Variedade da sua planta (Opcional)"
+        }
+      }
+    },
+    "error": {
+      "invalid_future_date": "Não é possível definir a data de rega no futuro.",
+      "name_exist": "Já existe uma planta com esse nome",
+      "upload_failed_generic": "Falha no upload do arquivo, algo deu errado.",
+      "upload_failed_type": "Falha no upload do arquivo, o tipo de arquivo não é um tipo de imagem suportado.",
+      "unknown": "Ocorreu um erro desconhecido."
+    },
+    "abort": {
+      "already_configured": "Esta entrada já está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Modifique a espécie ou a foto da sua planta. Se precisar de ajuda com a configuração, acesse: https://github.com/ndesgranges/simple-plant",
+        "data": {
+          "photo": "Foto",
+          "species": "Espécie/Variedade da sua planta (Opcional)"
+        }
+      }
+    },
+    "error": {
+      "upload_failed_type": "Falha no upload do arquivo, o tipo de arquivo não é um tipo de imagem suportado."
+    }
+  },
+  "entity": {
+    "button": {
+      "mark_watered": {
+        "name": "Marcar como regada"
+      },
+      "mark_fertilized": {
+        "name": "Marcar como adubada"
+      }
+    },
+    "binary_sensor": {
+      "todo": {
+        "name": "Para regar"
+      },
+      "problem": {
+        "name": "Regagem atrasada"
+      },
+      "todo_fertilization": {
+        "name": "Para adubar"
+      },
+      "problem_fertilization": {
+        "name": "Adubação atrasada"
+      }
+    },
+    "date": {
+      "last_watered": {
+        "name": "Última rega"
+      },
+      "last_fertilized": {
+        "name": "Última adubação"
+      }
+    },
+    "image": {
+      "picture": {
+        "name": "Foto"
+      }
+    },
+    "number": {
+      "days_between_waterings": {
+        "name": "Dias entre regas"
+      },
+      "days_between_fertilizations": {
+        "name": "Dias entre adubações"
+      }
+    },
+    "select": {
+      "health": {
+        "name": "Saúde atual",
+        "state": {
+          "notset": "Não definido",
+          "poor": "Pobre",
+          "fair": "Razoável",
+          "good": "Boa",
+          "verygood": "Muito boa",
+          "excellent": "Excelente"
+        }
+      }
+    },
+    "sensor": {
+      "next_watering": {
+        "name": "Próxima rega"
+      },
+      "next_fertilization": {
+        "name": "Próxima adubação"
+      }
+    }
+  },
+  "exceptions": {
+    "invalid_future_date": {
+      "message": "Não é possível definir a data de rega no futuro."
+    }
+  }
+}


### PR DESCRIPTION
### Summary:
This PR adds fertilization tracking support to the Simple Plant integration, mirroring the existing watering workflow.

### Changes:

`config_flow.py`: Added last_fertilized (date) and days_between_fertilizations (number) fields to the setup form. Includes validation to prevent future dates.

`coordinator.py`: Added fertilization logic:

async_set_last_fertilized() — manually sets the last fertilization date.
async_mark_as_fertilized_toggle() — toggles between today and the previous value (same behavior as the watering toggle).
get_fertilizer_dates() — computes last_fertilized, next_fertilization, and today from entity states.
date.py: Extended SimplePlantDate to support a last_fertilized date entity. Refactored fallback value initialization to be generic (keyed by description.key), defaulting to today when no value exists.

`number.py`: Added a days_between_fertilizations number entity.

`button.py`: Added a mark_fertilized button entity that calls async_mark_as_fertilized_toggle().

`binary_sensor.py`: Added SimplePlantFertilizationTodo and SimplePlantFertilizationProblem binary sensors, tracking whether fertilization is due or overdue.

`translations/en.json`: Added translations for all new fertilization entities.

`translations/pt-BR.json`: Added full Portuguese (Brazil) translation file.